### PR TITLE
feat: show 3 newest recommended artifacts

### DIFF
--- a/app/icons/Linux.tsx
+++ b/app/icons/Linux.tsx
@@ -1,0 +1,245 @@
+import { SVGProps } from "react";
+
+export function LinuxIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 256 295' {...props}>
+            <defs>
+                <linearGradient id='logosLinuxTux0' x1='48.548%' x2='51.047%' y1='115.276%' y2='41.364%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux1' x1='54.407%' x2='46.175%' y1='2.404%' y2='90.542%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.8} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux2' x1='51.86%' x2='47.947%' y1='88.248%' y2='9.748%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux3' x1='49.925%' x2='49.924%' y1='85.49%' y2='13.811%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux4' x1='53.901%' x2='45.956%' y1='3.102%' y2='93.895%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux5' x1='45.593%' x2='54.811%' y1='5.475%' y2='93.524%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux6' x1='49.984%' x2='49.984%' y1='89.845%' y2='40.632%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux7' x1='53.505%' x2='42.746%' y1='99.975%' y2='23.545%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux8' x1='49.841%' x2='50.241%' y1='13.229%' y2='94.673%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.8} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTux9' x1='49.927%' x2='50.727%' y1='37.327%' y2='92.782%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxa' x1='49.876%' x2='49.876%' y1='2.299%' y2='81.204%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxb' x1='49.833%' x2='49.824%' y1='2.272%' y2='71.799%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxc' x1='53.467%' x2='38.949%' y1='48.921%' y2='98.1%'>
+                    <stop offset='0%' stopColor='#FFA63F' />
+                    <stop offset='100%' stopColor='#FF0' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxd' x1='52.373%' x2='47.579%' y1='143.009%' y2='-64.622%'>
+                    <stop offset='0%' stopColor='#FFEED7' />
+                    <stop offset='100%' stopColor='#BDBFC2' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxe' x1='30.581%' x2='65.887%' y1='34.024%' y2='89.175%'>
+                    <stop offset='0%' stopColor='#FFA63F' />
+                    <stop offset='100%' stopColor='#FF0' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxf' x1='59.572%' x2='48.361%' y1='-17.216%' y2='66.118%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxg' x1='47.769%' x2='51.373%' y1='1.565%' y2='104.313%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxh' x1='43.55%' x2='57.114%' y1='4.533%' y2='92.827%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxi' x1='49.733%' x2='50.558%' y1='17.609%' y2='99.385%'>
+                    <stop offset='0%' stopColor='#FFA63F' />
+                    <stop offset='100%' stopColor='#FF0' />
+                </linearGradient>
+                <linearGradient id='logosLinuxTuxj' x1='50.17%' x2='49.68%' y1='2.89%' y2='94.17%'>
+                    <stop offset='0%' stopColor='#FFF' stopOpacity={0.65} />
+                    <stop offset='100%' stopColor='#FFF' stopOpacity={0} />
+                </linearGradient>
+                <filter
+                    id='logosLinuxTuxk'
+                    width='200%'
+                    height='200%'
+                    x='-50%'
+                    y='-50%'
+                    filterUnits='objectBoundingBox'
+                >
+                    <feOffset in='SourceAlpha' result='shadowOffsetOuter1' />
+                    <feGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation={6.5} />
+                </filter>
+            </defs>
+            <g fill='none'>
+                <path
+                    fill='#000'
+                    fillOpacity={0.2}
+                    d='M235.125 249.359c0 17.355-52.617 31.497-117.54 31.497S.044 266.806.044 249.359c0-17.356 52.618-31.498 117.54-31.498c64.924 0 117.45 14.142 117.541 31.498'
+                    filter='url(#logosLinuxTuxk)'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='#000'
+                    d='M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616c48.027-3.857 45.364 43.526 45.088 68.596c-.183 21.12 15.52 33.15 26.355 49.68c19.927 30.303 18.274 82.461-3.765 110.745c-27.916 35.354-51.791 20.018-67.678 21.304c-29.752 1.745-30.762 17.54-66.024-35.905'
+                />
+                <path
+                    fill='url(#logosLinuxTux0)'
+                    d='M169.1 122.451c8.265 7.622 29.661 41.69-4.224 62.995c-11.937 7.438 10.653 35.721 21.488 22.039c19.193-24.61 6.98-63.913-4.591-77.963c-7.714-9.917-19.651-13.774-12.672-7.07'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='#000'
+                    stroke='#000'
+                    strokeWidth={0.977}
+                    d='M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748c-11.846 7.806 10.468 32.508 23.049 19.927c43.618-43.894-1.102-94.308-16.53-111.664c-13.774-15.151-25.987 3.49-8.723 16.989z'
+                />
+                <path
+                    fill='url(#logosLinuxTux1)'
+                    d='M147.245 25.02c-.459 12.581-14.325 23.51-30.946 24.52c-16.621 1.01-29.66-8.54-29.202-21.121c.46-12.581 14.326-23.509 30.947-24.519c16.62-.918 29.66 8.54 29.201 21.12'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux2)'
+                    d='M107.483 54.957c.46 8.173-3.397 15.06-8.723 15.335c-5.326.276-10.01-6.06-10.469-14.233c-.459-8.173 3.398-15.06 8.724-15.335c5.326-.276 10.01 6.06 10.468 14.233'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux3)'
+                    d='M117.125 55.6c.184 9.458 6.337 16.988 13.683 16.805c7.346-.184 13.131-7.99 12.948-17.54c-.184-9.458-6.336-16.988-13.683-16.804c-7.346.183-13.223 8.08-12.948 17.539'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='#000'
+                    d='M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458c3.306 0 6.153-4.224 6.245-9.366c.091-5.234-2.48-9.459-5.878-9.459c-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356c-2.387.276-4.683-2.938-5.142-7.254c-.46-4.316 1.194-7.99 3.581-8.357c2.388-.275 4.684 2.939 5.143 7.255'
+                />
+                <path
+                    fill='url(#logosLinuxTux4)'
+                    d='M124.564 54.773c-.276 2.939 1.102 5.326 3.03 5.51c1.928.184 3.765-2.112 4.04-4.959c.276-2.938-1.102-5.326-3.03-5.51c-1.928-.183-3.765 2.113-4.04 4.96'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux5)'
+                    d='M99.953 55.508c.276 2.388-.734 4.5-2.203 4.683c-1.47.184-2.847-1.653-3.123-4.132c-.275-2.388.735-4.5 2.204-4.683c1.47-.184 2.847 1.744 3.122 4.132'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux6)'
+                    d='M71.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883c0-15.978 47.843-19.835 51.7-3.856c3.856 15.978 13.59 39.853 19.834 51.424c6.245 11.478 24.335 48.118 5.051 80.074c-17.356 28.284-69.973 50.69-98.073-3.856c-9.55-18.917-7.806-42.333.826-62.903'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux7)'
+                    d='M65.15 134.664c-5.601 10.56-17.172 38.293 11.112 53.445c30.395 16.162 30.303 49.312-6.245 33.517c-33.425-14.233-18.641-71.902-9.274-85.676c6.06-9.642 15.243-21.488 4.407-1.286'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='#000'
+                    stroke='#000'
+                    strokeWidth={1.25}
+                    d='M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484c38.384 23.6 27.548 47.108-7.53 25.895c-49.404-29.568-5.97-89.257 13.774-112.03c22.59-25.529 4.316 4.683-4.592 19.65z'
+                />
+                <path
+                    fill='url(#logosLinuxTux8)'
+                    d='M156.428 151.285c0 16.162-15.519 37.1-42.15 36.916c-27.456.183-39.118-20.754-39.118-36.916c0-16.161 18.182-29.293 40.588-29.293c22.498.092 40.68 13.132 40.68 29.293'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTux9)'
+                    d='M141.92 100.504c-.276 16.713-11.204 20.662-24.978 20.662c-13.775 0-23.784-2.48-24.978-20.662c0-11.387 11.203-17.998 24.978-17.998c13.774-.092 24.977 6.52 24.977 17.998'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxa)'
+                    d='M58.63 126.216c9-13.682 28.008-34.711 3.582 2.939c-19.835 31.038-7.346 50.965-.918 56.474c18.549 16.53 17.814 27.64 3.214 18.917c-31.314-18.641-24.794-50.047-5.878-78.33'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxb)'
+                    d='M188.936 131.818c-7.806-16.07-32.6-56.842 1.193-9.459c30.763 42.884 9.183 72.729 5.326 75.667c-3.856 2.939-16.804 8.908-13.04-1.469c3.858-10.377 22.958-30.028 6.52-64.74'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxc)'
+                    stroke='#E68C3F'
+                    strokeWidth={6.25}
+                    d='M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457c2.204-6.704-3.214-16.805.275-23.325c4.133-7.989 13.04-6.244 18.366-11.57c5.234-5.51 8.54-15.06 18.366-13.59c9.734 1.468 16.254 13.406 23.049 28.099c5.05 10.468 22.865 25.253 21.672 37.007c-1.47 17.998-21.948 21.396-42.15 10.836z'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxd)'
+                    d='M201.608 189.119c-3.122 5.877-16.162 15.335-24.886 12.856c-8.815-2.388-12.856-15.795-11.111-25.988c1.653-11.386 11.111-12.03 23.05-6.336c12.855 6.336 16.712 11.662 12.947 19.468'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxe)'
+                    stroke='#E68C3F'
+                    strokeWidth={6.251}
+                    d='M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577c-4.775-5.418-3.306-16.989-9.183-21.947c-6.887-6.061-14.509-1.102-21.488-4.224c-6.979-3.398-14.325-9.918-22.865-5.327c-8.54 4.684-9.459 16.805-10.285 32.783c-.735 11.479-11.203 30.671-5.602 41.231c8.081 16.346 29.11 14.142 43.435-2.938z'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxf)'
+                    d='M187.925 229.064c23.325-34.435 5.97-34.16.092-36.823c-5.877-2.755-12.03-8.173-18.916-4.408c-6.888 3.857-7.255 13.775-7.439 26.814c-.275 9.367-8.08 25.07-3.397 33.793c5.693 10.193 19.467-4.591 29.66-19.376'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxg)'
+                    d='M47.06 234.023c-34.895-22.59-18.55-30.303-13.315-33.885c6.336-4.591 6.428-13.407 14.233-12.58c7.806.826 12.397 10.468 17.631 22.406c3.857 8.54 17.264 19.927 16.254 29.753c-1.285 11.57-19.743 3.948-34.803-5.694'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='#000'
+                    d='M209.588 188.843c-2.755 4.776-13.958 12.306-21.396 10.285c-7.622-1.928-11.112-12.672-9.55-20.753c1.377-9.183 9.55-9.642 19.834-5.05c10.928 4.958 14.326 9.182 11.112 15.518'
+                />
+                <path
+                    fill='url(#logosLinuxTuxh)'
+                    d='M192.058 186.18c-1.745 3.306-9.091 8.54-14.234 7.163c-5.142-1.377-7.713-8.815-6.887-14.417c.735-6.336 6.244-6.704 13.223-3.581c7.53 3.49 9.918 6.428 7.898 10.835'
+                    transform='translate(10)'
+                />
+                <path
+                    fill='url(#logosLinuxTuxi)'
+                    stroke='#E68C3F'
+                    strokeWidth={3.75}
+                    d='M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939c3.122 2.02 5.693 2.204 11.662 4.775c12.03 4.96 6.336 16.897-6.52 20.937c-5.51 1.745-10.468 8.449-20.386 7.806c-8.54-.46-10.744-6.06-15.978-9.091c-9.275-5.234-10.652-12.305-5.602-16.07c5.051-3.765 6.98-5.143 7.347-5.418z'
+                    transform='translate(10)'
+                />
+                <path
+                    stroke='#E68C3F'
+                    strokeWidth={2.5}
+                    d='M148.43 75.986c-5.05.275-15.979 11.203-27.457 11.203c-11.479 0-18.366-10.652-20.11-10.652'
+                />
+                <path
+                    fill='url(#logosLinuxTuxj)'
+                    d='M102.8 65.426c1.837-1.653 7.622-6.153 15.244-1.562c1.653.919 3.306 1.929 5.693 3.306c4.867 2.847 2.48 6.98-3.398 9.55c-2.663 1.102-7.07 3.49-10.376 3.306c-3.673-.367-6.153-2.755-8.54-4.316c-4.5-2.938-4.224-5.418-2.112-7.346c1.56-1.47 3.305-2.847 3.49-2.938'
+                    transform='translate(10)'
+                />
+            </g>
+        </svg>
+    );
+}

--- a/app/icons/Windows.tsx
+++ b/app/icons/Windows.tsx
@@ -1,0 +1,12 @@
+import type { SVGProps } from "react";
+
+export function WindowsIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg viewBox='0 0 88 88' xmlns='http://www.w3.org/2000/svg' height='1em' width='1em' {...props}>
+            <path
+                d='m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z'
+                fill='#00adef'
+            />
+        </svg>
+    );
+}

--- a/app/icons/index.tsx
+++ b/app/icons/index.tsx
@@ -1,0 +1,4 @@
+import { WindowsIcon } from "./Windows";
+import { LinuxIcon } from "./Linux";
+
+export { WindowsIcon, LinuxIcon };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { getRecommendedArtifacts, type RecommendedArtifact } from "@/actions/fivem";
 import artifactDb from "@/db.json";
+import { WindowsIcon, LinuxIcon } from "./icons";
 
 export default async function Home() {
   const recommendedArtifacts: RecommendedArtifact[] | false = await getRecommendedArtifacts();
@@ -30,10 +31,18 @@ export default async function Home() {
             </code>
           </p>
 
-          <div className="flex gap-2">
-            <p>Download: </p>
-            <a href={recommendedArtifacts[0].downloadLinks.windows} className="underline text-blue-500">Windows</a>
-            <a href={recommendedArtifacts[0].downloadLinks.linux} className="underline text-blue-500">Linux</a>
+          <div className="flex items-center mt-2">
+            <p className="mr-2">Download</p>
+
+            <div className="gap-2 flex">
+              <a href={recommendedArtifacts[0].downloadLinks.windows} className="w-8 h-8 bg-gray-50 hover:bg-gray-300 transition-colors flex items-center justify-center">
+                <WindowsIcon className="w-full h-full p-1 transition-[display] group-hover:hidden" />
+              </a>
+
+              <a href={recommendedArtifacts[0].downloadLinks.linux} className="w-8 h-8 bg-gray-50 hover:bg-gray-300 transition-colors flex items-center justify-center">
+                <LinuxIcon className="w-full h-full p-1" />
+              </a>
+            </div>
           </div>
         </div>
 
@@ -47,8 +56,13 @@ export default async function Home() {
               </code>
 
               <div className="gap-2 flex">
-                <a href={artifact.downloadLinks.windows} className="underline text-blue-500">Windows</a>
-                <a href={artifact.downloadLinks.linux} className="underline text-blue-500">Linux</a>
+                <a href={artifact.downloadLinks.windows} className="w-6 h-6 bg-gray-50 hover:bg-gray-300 transition-colors flex items-center justify-center">
+                  <WindowsIcon className="w-full h-full p-1 transition-[display] group-hover:hidden" />
+                </a>
+
+                <a href={artifact.downloadLinks.linux} className="w-6 h-6 bg-gray-50 hover:bg-gray-300 transition-colors flex items-center justify-center">
+                  <LinuxIcon className="w-full h-full p-1" />
+                </a>
               </div>
             </div>
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,10 @@
-import { getRecommendedArtifact } from "@/actions/fivem";
+import { getRecommendedArtifacts, type RecommendedArtifact } from "@/actions/fivem";
 import artifactDb from "@/db.json";
 
 export default async function Home() {
-  const data:
-    | {
-        windowsDownloadLink: string;
-        linuxDownloadLink: string;
-        recommendedArtifact: string;
-      }
-    | false = await getRecommendedArtifact();
+  const recommendedArtifacts: RecommendedArtifact[] | false = await getRecommendedArtifacts();
 
-  if (!data)
+  if (!recommendedArtifacts)
     return (
       <div className="p-4 text-center text-red-500 font-bold">
         Could not fetch artifacts data. Please try again later.
@@ -21,33 +15,52 @@ export default async function Home() {
     <div className="max-w-[500px] min-w-[300px] p-5 mx-auto">
       <h1 className="text-2xl font-bold mb-5">FiveM Artifacts DB</h1>
 
-      <div className="border-green-500 border-2 p-3 px-4 mb-5 text-lg">
-        <p>
-          <span>Latest artifact with no reported issues</span>
-          <code className="bg-green-500 p-1 px-2 ml-2 text-white font-bold">
-            {data.recommendedArtifact}
-          </code>
-        </p>
-        <div className="flex gap-2">
-          <p>Download:</p>
-          <a
-            href={data.windowsDownloadLink}
-            className="text-blue-500 underline"
-          >
-            Windows
-          </a>
-          <a href={data.linuxDownloadLink} className="text-blue-500 underline">
-            Linux
-          </a>
+      <div className="mb-5">
+        {recommendedArtifacts[0].isLatest && (
+          <div className="text-orange-400 font-bold text-xs mb-2">
+            This is the newest artifact. It may be unstable or have unknown issues.
+          </div>
+        )}
+
+        <div className="border-green-500 border-2 p-3 text-lg mb-2">
+          <p>
+            <span>Latest artifact with no reported issues</span>
+            <code className="bg-green-500 p-1 px-2 ml-2 text-white font-bold">
+              {recommendedArtifacts[0].artifact}
+            </code>
+          </p>
+
+          <div className="flex gap-2">
+            <p>Download: </p>
+            <a href={recommendedArtifacts[0].downloadLinks.windows} className="underline text-blue-500">Windows</a>
+            <a href={recommendedArtifacts[0].downloadLinks.linux} className="underline text-blue-500">Linux</a>
+          </div>
+        </div>
+
+        <div className="flex w-full justify-between gap-2 flex-wrap">
+          {recommendedArtifacts.slice(1).map((artifact) => (
+            <div key={artifact.artifact} className="border border-gray-500 p-2 text-sm flex flex-grow justify-between gap-2">
+              <code className="leading-6">
+                <span className="bg-green-500 p-1 px-2 text-white font-bold">
+                  {artifact.artifact}
+                </span>
+              </code>
+
+              <div className="gap-2 flex">
+                <a href={artifact.downloadLinks.windows} className="underline text-blue-500">Windows</a>
+                <a href={artifact.downloadLinks.linux} className="underline text-blue-500">Linux</a>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
 
-      <div className="flex justify-between mb-2 text-xs">
+      <div className="flex justify-between mb-2 text-xs flex-wrap-reverse gap-y-1 gap-x-8">
         <p className="text-gray-400">Artifacts with reported issues:</p>
         <a
           href="https://github.com/jgscripts/fivem-artifacts-db/tree/main?tab=readme-ov-file#contributing"
           target="_blank"
-          className="underline text-blue-500 text-right"
+          className="underline text-blue-500"
         >
           Know an issue? Let us know!
         </a>
@@ -57,16 +70,14 @@ export default async function Home() {
         .sort((a, b) => parseInt(b[0]) - parseInt(a[0]))
         .map(([key, value]) => (
           <div key={key} className="border border-gray-500 p-2 mb-2 text-sm">
-            <code className="leading-5">
+            <code className="leading-6">
               <span className="bg-red-500 p-1 px-2 mr-2 text-white font-bold">
                 {key}
               </span>
-              <span className="text-gray-300">{value}</span>
+              <span className="text-gray-300 break-words">{value}</span>
             </code>
           </div>
         ))}
-
-      <div></div>
     </div>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "esnext",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
This PR adds the following:

- Last 3 artifacts with no reported issues are now shown.
The reason behind this is that the newest artifacts (which could be just few hours old) may be unstable or have yet unknown issues that are often fixed in the following build.
If the latest recommended artifact is also the newest artifacts, small notice is shown to warn people.
![image](https://github.com/user-attachments/assets/eab59f6d-bbe5-42b6-9d6f-e0f437e80c1b)

- Download links for Windows and Linux are changed to buttons with their respective system icons (taken from [svgl.app](https://svgl.app/))

- Also made few mobile layout responsivity changes
![image](https://github.com/user-attachments/assets/be9f6188-dba8-4eb1-8ad6-385078df9bad)
