### PR TITLE
SetPlayerModel Causes SIGSEGV crashes

### DIFF
--- a/db.json
+++ b/db.json
@@ -5,6 +5,7 @@
     "10191": "GetVehicleNumberPlateText server native broken, will cause issues with scripts involving vehicles",
     "10268-10309": "sv_experimentalNetGameEventHandler enabled by default; can cause server crashing and reports of issues downgrading after upgrading",
     "10930": "Failed build, ignore",
-    "12078-12083": "Some clients will fail to connect with 'ReadBulk of header failed' error"
+    "12078-12083": "Some clients will fail to connect with 'ReadBulk of header failed' error",
+    "12078-12135": "SetPlayerModel may cause SIGSEGV crashes on some clients due to changes in player handling. 12031 and below works fine."
   }
 }


### PR DESCRIPTION
SetPlayerModel cause SIGSEGV crashes on some clients due to changes in player handling. 12031 and below works fine.
