### PR TITLE
[fix] Update artifact being capped to 24574 + update dependencies

### DIFF
--- a/actions/fivem.ts
+++ b/actions/fivem.ts
@@ -1,7 +1,7 @@
 import artifactDb from "@/db.json";
 
 const GITHUB_REPO_TAGS =
-  "https://api.github.com/repos/citizenfx/fivem/tags?per_page=50";
+  "https://api.github.com/repos/citizenfx/fivem/tags?per_page=100";
 const DOWNLOAD_LINK_BASE = "https://runtime.fivem.net/artifacts/fivem";
 const WINDOWS_MASTER = "build_server_windows/master";
 const WINDOWS_FILE = "server.zip";

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^20.19.33",
     "@types/react": "19.0.4",
     "@types/react-dom": "19.0.2",
-    "eslint": "^8",
+    "eslint": "^8.57.1",
     "eslint-config-next": "15.1.4",
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.19",
+    "typescript": "^5.9.3"
   },
   "overrides": {
     "@types/react": "19.0.4",


### PR DESCRIPTION
I just increased the tabs 

old:

<img width="1920" height="1152" alt="brave_u5cOdg1IJF" src="https://github.com/user-attachments/assets/6362af80-fb6f-429d-8065-a2bc029b6974" />


new:

<img width="1920" height="1152" alt="brave_0WbYW9NEP8" src="https://github.com/user-attachments/assets/ad14dab1-5049-4a3f-a711-afcaef104d7e" />

