### PR TITLE
Add 26261-27417 because of Yarn failing to build resources

### DIFF
--- a/db.json
+++ b/db.json
@@ -24,6 +24,7 @@
     "17462": "Failed build, ignore",
     "21547": "Multiple (unconfirmed) reports of server-sided natives throwing errors or causing crashes; best to avoid",
     "25943": "Failed build",
-    "25963-25988": "Node.js sandboxing seems to be causing issues for people - best to avoid for now"
+    "25963-25988": "Node.js sandboxing seems to be causing issues for people - best to avoid for now",
+    "26261-27417": "Issues with building Yarn resources on some Linux servers"
   }
 }

--- a/db.json
+++ b/db.json
@@ -24,7 +24,7 @@
     "17462": "Failed build, ignore",
     "21547": "Multiple (unconfirmed) reports of server-sided natives throwing errors or causing crashes; best to avoid",
     "25943": "Failed build",
-    "25963-25988": "Node.js sandboxing seems to be causing issues for people - best to avoid for now",
+    "25839-25988": "Node.js sandboxing seems to be causing issues for people - best to avoid for now",
     "26261-27417": "Issues with building Yarn resources on some Linux servers"
   }
 }


### PR DESCRIPTION
On some Linux servers (weirdly not all) the new system_resources version of Yarn (25770+) crashes while building, which means the resource never starts. Very prominent on RedM servers, which use Yarn for the default (and required) resource sessionmanager-rdr3. On FiveM it can easily be triggered with screenshot-basic or by using `set resources_useSystemChat false` and the cfx-server-data version of the chat resource.

Also the Node.js sandboxing changes were introduced in 25839, not 25963 so fixing that as well. Leaves 25770 as latest stable.

<img width="758" height="230" alt="image" src="https://github.com/user-attachments/assets/15bb7d5d-bcf3-443e-9c2d-40e7559818c8" />

<img width="1081" height="133" alt="image" src="https://github.com/user-attachments/assets/0f60e1ba-9cfb-4106-a472-97a43ecfbfaf" />


